### PR TITLE
Fixed rt.cpan.org bug #77399, No space allowed in section names

### DIFF
--- a/lib/Nagios/Plugin/Getopt.pm
+++ b/lib/Nagios/Plugin/Getopt.pm
@@ -338,7 +338,7 @@ sub _process_extra_opts
     my $file = '';
 
     # Parse section@file
-    if ($extopts =~ m/^(\w*)@(.*?)\s*$/) {
+    if ($extopts =~ m/^([^@]*)@(.*?)\s*$/) {
       $section = $1;
       $file = $2;
     }


### PR DESCRIPTION
Hi,
this commit should fix rt.cpan.org bug #77399. (https://rt.cpan.org/Public/Bug/Display.html?id=77399)
It now allows the section names to contain all characters except "@".

If the patch is fine please merge, Thanks!

regards,
Richard
