### PR TITLE
output empty values as "U"

### DIFF
--- a/lib/Monitoring/Plugin/Performance.pm
+++ b/lib/Monitoring/Plugin/Performance.pm
@@ -64,9 +64,16 @@ sub perfoutput {
 	if ($label =~ / /) {
 		$label = "'$label'";
 	}
+	
+	my $value = $self->value;
+	# To prevent invalid output, we change empty value to value "U"
+	if ($value eq '') {
+		$value = 'U';
+    }
+    
     my $out = sprintf "%s=%s%s;%s;%s;%s;%s",
         $label,
-        $self->value,
+        $value,
         $self->_nvl($self->uom),
         $self->_nvl($self->warning),
         $self->_nvl($self->critical),


### PR DESCRIPTION
output empty performance data value as value "U" to "indicate that the actual value couldn't be determined" (defined in https://nagios-plugins.org/doc/guidelines.html#AEN200) and do valid output