### PR TITLE
Support LONGTEXT output

### DIFF
--- a/lib/Monitoring/Plugin/Functions.pm
+++ b/lib/Monitoring/Plugin/Functions.pm
@@ -118,7 +118,10 @@ sub plugin_exit {
 
     # Setup output
     my $output = "$STATUS_TEXT{$code}";
-    $output .= " - $message" if defined $message && $message ne '';
+    if (defined $message && $message ne '') {
+        $output .= " - " unless $message =~ /^[ \f\r\t\w]*\n/;
+        $output .= $message;
+    }
     my $shortname = ($arg->{plugin} ? $arg->{plugin}->shortname : undef);
     $shortname ||= get_shortname(); # Should happen only if funnctions are called directly
     $output = "$shortname $output" if $shortname;


### PR DESCRIPTION
Pass `TEXT OUTPUT\nLONGOUTPUT1\nLONGOUTPUT2` as the second parameter to `plugin_exit()` to add LONGOUTPUT lines.  If the parameter is has a leading newline (i.e. `\nLONGTEXT1\nLONGTEXT2`), skip emitting the hyphen (dash).