### PR TITLE
Fix plugin-name processing in ALRM handler.

### DIFF
--- a/lib/Monitoring/Plugin/Getopt.pm
+++ b/lib/Monitoring/Plugin/Getopt.pm
@@ -445,7 +445,7 @@ sub getopts
   # Setup default alarm handler for alarm($ng->timeout) in plugin
   $SIG{ALRM} = sub {
     my $plugin = uc $self->{_attr}->{plugin};
-    $plugin =~ s/^CHECK_//;
+    $plugin =~ s/^CHECK[-_]//;
     $self->_die(
       sprintf("%s UNKNOWN - plugin timed out (timeout %ss)",
         $plugin, $self->timeout));

--- a/lib/Monitoring/Plugin/Getopt.pm
+++ b/lib/Monitoring/Plugin/Getopt.pm
@@ -445,7 +445,7 @@ sub getopts
   # Setup default alarm handler for alarm($ng->timeout) in plugin
   $SIG{ALRM} = sub {
     my $plugin = uc $self->{_attr}->{plugin};
-    $plugin =~ s/^check_//;
+    $plugin =~ s/^CHECK_//;
     $self->_die(
       sprintf("%s UNKNOWN - plugin timed out (timeout %ss)",
         $plugin, $self->timeout));


### PR DESCRIPTION
The regex is using the wrong case so it never matches.  I've also adjusted it to allow either a hypen (-) or underscore (_).