### PR TITLE
Allow negation of command line arguments using '--no'-prefix

### DIFF
--- a/lib/Monitoring/Plugin/Getopt.pm
+++ b/lib/Monitoring/Plugin/Getopt.pm
@@ -81,14 +81,15 @@ sub _spec_to_help
 {
   my ($self, $spec, $label) = @_;
 
-  my ($opts, $type) = split /=|:/, $spec, 2;
+  my ($opts, $type) = split /=|:|!/, $spec, 2;
   my $optional = ($spec =~ m/:/);
+  my $boolean = ($spec =~ m/!/);
   my (@short, @long);
   for (split /\|/, $opts) {
     if (length $_ == 1) {
       push @short, "-$_";
     } else {
-      push @long, "--$_";
+      push @long, $boolean ? "--[no-]$_" : "--$_";
     }
   }
 
@@ -207,7 +208,7 @@ sub _process_specs_getopt_long
     # Setup names and defaults
     my $spec = $arg->{spec};
     # Use first arg as name (like Getopt::Long does)
-    $spec =~ s/[=:].*$//;
+    $spec =~ s/[=:!].*$//;
     my $name = (split /\s*\|\s*/, $spec)[0];
     $arg->{name} = $name;
     if (defined $self->{$name}) {
@@ -697,7 +698,8 @@ but basically it is a series of one or more argument names for this argument
 (separated by '|'), suffixed with an '=<type>' indicator if the argument
 takes a value. '=s' indicates a string argument; '=i' indicates an integer
 argument; appending an '@' indicates multiple such arguments are accepted;
-and so on. The following are some examples:
+appending an '!' indicates negation using '--no'-prefix is possible; and so on.
+The following are some examples:
 
 =over 4
 
@@ -708,6 +710,8 @@ and so on. The following are some examples:
 =item ports|port|p=i
 
 =item exclude|X=s@
+
+=item perfdata!
 
 =item verbose|v+
 

--- a/t/Monitoring-Plugin-Getopt-01.t
+++ b/t/Monitoring-Plugin-Getopt-01.t
@@ -2,7 +2,7 @@
 
 use strict;
 
-use Test::More tests => 76;
+use Test::More tests => 81;
 BEGIN { use_ok('Monitoring::Plugin::Getopt') };
 
 # Needed to get evals to work in testing
@@ -35,6 +35,13 @@ sub setup
     required => 1,
   );
 
+  # Add argument - boolean, supporting --no-prefix
+  $ng->arg(
+    spec => 'perfdata!',
+    help => qq(Provide performance data),
+    default => 1,
+  );
+
   return $ng;
 }
 
@@ -47,6 +54,13 @@ $ng->getopts;
 is($ng->warning, 3, 'warning set to 3');
 is($ng->critical, 10, 'critical set to 10');
 is($ng->timeout, 12, 'timeout set to 12');
+is($ng->perfdata, 1, 'perfdata set to default of 1');
+
+# Disable perfdata
+@ARGV = qw(--critical 10 --no-perfdata);
+$ng = setup;
+$ng->getopts;
+is($ng->perfdata, 0, 'perfdata set to 0');
 
 # Check multiple verbose flags
 @ARGV = qw(-w 3 --critical 10 -v -v -v);
@@ -131,6 +145,7 @@ like($@, qr/--version/, 'help includes default options 1');
 like($@, qr/--verbose/, 'help includes default options 2');
 like($@, qr/--warning/, 'help includes custom option 1');
 like($@, qr/--critical/, 'help includes custom option 2');
+like($@, qr/--\[no-\]perfdata\n/, 'help includes custom option 3');
 unlike($@, qr/Missing arg/, 'no missing arguments');
 
 @ARGV = ( '--help' );
@@ -146,4 +161,5 @@ like($@, qr/--version/, 'help includes default options 1');
 like($@, qr/--verbose/, 'help includes default options 2');
 like($@, qr/--warning/, 'help includes custom option 1');
 like($@, qr/-c, --critical=INTEGER/, 'help includes custom option 2, with expanded args');
+like($@, qr/--\[no-\]perfdata\n/, 'help includes custom option 3');
 unlike($@, qr/Missing arg/, 'no missing arguments');


### PR DESCRIPTION
`Getopt::Long` supports [negatable boolean options](https://metacpan.org/pod/Getopt::Long#A-little-bit-less-simple-options) by appending an `!` to the option specification, so this allows to use this functionality with `Monitoring::Plugin::Getopt` as well. This actually already kind-of worked, but with not very useful help output and the way one had to access the option value depended on if the option was passed on the command line or not.