### PR TITLE
Clean up argument adding code a little bit

### DIFF
--- a/lib/Monitoring/Plugin/Getopt.pm
+++ b/lib/Monitoring/Plugin/Getopt.pm
@@ -392,7 +392,7 @@ sub arg
   );
 
   # Named args
-  if ($_[0] =~ m/^(spec|help|required|default|label)$/ && scalar(@_) % 2 == 0) {
+  if (exists $params{$_[0]} && scalar(@_) % 2 == 0) {
     %args = validate( @_, { %params });
   }
 

--- a/lib/Monitoring/Plugin/Getopt.pm
+++ b/lib/Monitoring/Plugin/Getopt.pm
@@ -393,7 +393,7 @@ sub arg
 
   # Named args
   if (exists $params{$_[0]} && scalar @_ % 2 == 0) {
-    %args = validate( @_, { %params });
+    %args = validate( @_, \%params );
   }
 
   # Positional args

--- a/lib/Monitoring/Plugin/Getopt.pm
+++ b/lib/Monitoring/Plugin/Getopt.pm
@@ -392,7 +392,7 @@ sub arg
   );
 
   # Named args
-  if (exists $params{$_[0]} && scalar @_ % 2 == 0) {
+  if (exists $params{$_[0]} && @_ % 2 == 0) {
     %args = validate( @_, \%params );
   }
 

--- a/lib/Monitoring/Plugin/Getopt.pm
+++ b/lib/Monitoring/Plugin/Getopt.pm
@@ -382,15 +382,18 @@ sub arg
   my $self = shift;
   my %args;
 
+  # Param name to required boolean
+  my %params = (
+      spec     => 1,
+      help     => 1,
+      default  => 0,
+      required => 0,
+      label    => 0,
+  );
+
   # Named args
   if ($_[0] =~ m/^(spec|help|required|default|label)$/ && scalar(@_) % 2 == 0) {
-    %args = validate( @_, {
-      spec => 1,
-      help => 1,
-      default => 0,
-      required => 0,
-      label => 0,
-    });
+    %args = validate( @_, { %params });
   }
 
   # Positional args

--- a/lib/Monitoring/Plugin/Getopt.pm
+++ b/lib/Monitoring/Plugin/Getopt.pm
@@ -392,7 +392,7 @@ sub arg
   );
 
   # Named args
-  if (exists $params{$_[0]} && scalar(@_) % 2 == 0) {
+  if (exists $params{$_[0]} && scalar @_ % 2 == 0) {
     %args = validate( @_, { %params });
   }
 

--- a/lib/Monitoring/Plugin/Getopt.pm
+++ b/lib/Monitoring/Plugin/Getopt.pm
@@ -398,14 +398,8 @@ sub arg
 
   # Positional args
   else {
-    my @args = validate_pos(@_, 1, 1, 0, 0, 0);
-    %args = (
-      spec      => $args[0],
-      help      => $args[1],
-      default   => $args[2],
-      required  => $args[3],
-      label     => $args[4],
-    );
+    my @order = qw(spec help default required label);
+    @args{@order} = validate_pos(@_, @params{@order});
   }
 
   # Add to private args arrayref


### PR DESCRIPTION
This changeset streamlines the code in the subroutine Monitoring::Plugin::Getopt::arg() that is used for validating and adding new arguments to the plugin, completing some changes I've wanted since my commit 4aa2aee to make the code a bit more robust if and when new argument parameters are introduced. I have run the included test suite on Perl 5.26.1 and Perl 5.8.1 and it passes.