### PR TITLE
Implicitly creating a threshold object in getopts rather than check_threshold

### DIFF
--- a/lib/Monitoring/Plugin.pm
+++ b/lib/Monitoring/Plugin.pm
@@ -131,8 +131,7 @@ sub check_threshold {
 
 	# in order of preference, get warning and critical from
 	#  1.  explicit arguments to check_threshold
-	#  2.  previously explicitly set threshold object
-	#  3.  implicit options from Getopts object
+	#  2.  previously explicitly set threshold object or implicit theshold object created by warning and critical
 	if ( exists $args{warning} || exists $args{critical} ) {
 		$self->set_thresholds(
 			warning  => $args{warning},
@@ -141,12 +140,6 @@ sub check_threshold {
 	}
 	elsif ( defined $self->threshold ) {
 		# noop
-	}
-	elsif ( defined $self->opts ) {
-		$self->set_thresholds(
-			warning  => $self->opts->warning,
-			critical => $self->opts->critical,
-		);
 	}
 	else {
 		return UNKNOWN;
@@ -163,6 +156,10 @@ sub add_arg {
 sub getopts {
     my $self = shift;
 	$self->opts->getopts(@_) if $self->_check_for_opts;
+	$self->set_thresholds(
+		warning  => $self->opts->warning,
+		critical => $self->opts->critical,
+	) if ( defined $self->opts->warning && defined $self->opts->critical );
 }
 
 sub _check_for_opts {


### PR DESCRIPTION
Previously, the call to `check_threshold` would set the threshold on the Monitoring::Plugin object, if thresholds are defined, this means that these 2 snippets have different behaviour:
```
my $returnCode = $mp->check_threshold($connectionCount);

$mp->add_perfdata(
        label => "OpenVPN clients",
        value => $connectionCount,
        threshold => $mp->threshold
);

$mp->plugin_exit(
        return_code => $returnCode,
        message => $connectionCount . " OpenVPN clients"
);
```

```
$mp->add_perfdata(
        label => "OpenVPN clients",
        value => $connectionCount,
        threshold => $mp->threshold
);

$mp->plugin_exit(
        return_code => $mp->check_threshold($connectionCount),
        message => $connectionCount . " OpenVPN clients"
);
```
To us, this is unexpected. The first snippet, will have thresholds on the perfdata, whereas the second will not. This PR should change the behaviour so that `$mp->threshold` will exist from as early as possible, so need to run `check_threshold` before `add_perfdata` is no longer there.

Open to alternatives if this introduces some behaviour we're not aware of