### PR TITLE
Create implicit threshold object if either warning or critical is set

### DIFF
--- a/lib/Monitoring/Plugin.pm
+++ b/lib/Monitoring/Plugin.pm
@@ -159,7 +159,7 @@ sub getopts {
 	$self->set_thresholds(
 		warning  => $self->opts->warning,
 		critical => $self->opts->critical,
-	) if ( defined $self->opts->warning && defined $self->opts->critical );
+	) if ( defined $self->opts->warning || defined $self->opts->critical );
 }
 
 sub _check_for_opts {


### PR DESCRIPTION
As suggested in: https://github.com/monitoring-plugins/monitoring-plugin-perl/pull/22#discussion_r486051909

Previously, the plugin would have to define both the warning and criticals to get the automatic threshold object. Now, if either is set it will create the plugin threshold object