### PR TITLE
Fix an incorrect hyphen removal due to a double linefeed

### DIFF
--- a/lib/Monitoring/Plugin/Functions.pm
+++ b/lib/Monitoring/Plugin/Functions.pm
@@ -119,7 +119,7 @@ sub plugin_exit {
     # Setup output
     my $output = "$STATUS_TEXT{$code}";
     if (defined $message && $message ne '') {
-        $output .= " - " unless $message =~ /^\s*\n/mxs;
+        $output .= " - " unless $message =~ /^\s*[\n\r]/;
         $output .= $message;
     }
     my $shortname = ($arg->{plugin} ? $arg->{plugin}->shortname : undef);

--- a/t/Monitoring-Plugin-Functions-01.t
+++ b/t/Monitoring-Plugin-Functions-01.t
@@ -1,6 +1,6 @@
 
 use strict;
-use Test::More tests => 116;
+use Test::More tests => 117;
 
 BEGIN { use_ok("Monitoring::Plugin::Functions", ":all"); }
 Monitoring::Plugin::Functions::_fake_exit(1);
@@ -90,15 +90,14 @@ for (@ugly2) {
 
 # plugin_exit message with longoutput
 my @ugly3 = (
-    [ "MSG\nLONGOUTPUT", " - MSG\nLONGOUTPUT" ],
-    [ "\nLONGOUTPUT",    "\nLONGOUTPUT" ],
-    [ "   \nLONGOUTPUT", "   \nLONGOUTPUT" ],
+    [ "MSG\nLONGOUTPUT", "MONITORING-PLUGIN-FUNCTIONS-01 CRITICAL - MSG\nLONGOUTPUT\n" ],
+    [ "\nLONGOUTPUT",    "MONITORING-PLUGIN-FUNCTIONS-01 CRITICAL\nLONGOUTPUT\n" ],
+    [ "   \nLONGOUTPUT", "MONITORING-PLUGIN-FUNCTIONS-01 CRITICAL   \nLONGOUTPUT\n" ],
+    [ "LONGOUTPUT\n\n    blah.", "MONITORING-PLUGIN-FUNCTIONS-01 CRITICAL - LONGOUTPUT\n\n    blah.\n" ],
 );
 for (@ugly3) {
     $r = plugin_exit(CRITICAL, $_->[0]);
-    like($r->message, qr/CRITICAL$_->[1]$/,
-         sprintf('plugin_exit(CRITICAL, $msg) output matched "%s"',
-                 "CRITICAL$_->[1]"));
+    is($r->message, $_->[1], "plugin_exit() output as expected");
 }
 
 # Test plugin_die( $msg )


### PR DESCRIPTION
Given a message of "LONGOUTPUT\n\n  blah.", the plugin_exit() message gave: "MONITORING-PLUGIN-FUNCTIONS-01 CRITICALLONGOUTPUT\n\n    blah.\n", which was wrong.

This was located as the regex in this line:
```
$output .= " - " unless $message =~ /^\s*\n/mxs;
```

I have amended the line to:
```
$output .= " - " unless $message =~ /^\s*[\n\r]/;
```

which kinda makes sense - it means if the message starts with (optional) spaces and then a linefeed, ignore the hyphen. The previous modifiers of /mxs started to match other parts of the string.

Have added a test case to cover this and also update the test to check for the precise output (rather than the looser regex check).